### PR TITLE
GCPFirewall: make status a subresource.

### DIFF
--- a/apis/gcpfirewall/v1/types.go
+++ b/apis/gcpfirewall/v1/types.go
@@ -32,6 +32,7 @@ type CIDR string
 // +genclient:nonNamespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=gf,scope=Cluster
 
 // GCPFirewall describes a GCP firewall spec that can be used to configure GCE

--- a/apis/gcpfirewall/v1beta1/types.go
+++ b/apis/gcpfirewall/v1beta1/types.go
@@ -31,6 +31,7 @@ type CIDR string
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=gf,scope=Cluster
 
 // GCPFirewall describes a GCP firewall spec that can be used to configure GCE

--- a/config/crds/networking.gke.io_gcpfirewalls.yaml
+++ b/config/crds/networking.gke.io_gcpfirewalls.yaml
@@ -280,6 +280,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1beta1
     schema:
       openAPIV3Schema:
@@ -531,3 +533,5 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}


### PR DESCRIPTION
This change is safe as the GCPFirewall CRD is not enabled anywhere yet.