### PR TITLE
Revert "network annotation to hold egress NAT gateway IP"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Status conditions to be used for validation updates for GNPs with `NetworkAttachment`.
 - Innterface-status annotation was added to pod.
-- Network annotation to hold egress NAT gateway IP.
 - The `NodeTopology` CRD definition.
 - The `description` field in the GCPFirewall CRD.
 

--- a/apis/network/v1/annotations.go
+++ b/apis/network/v1/annotations.go
@@ -67,8 +67,6 @@ const (
 	NICInfoAnnotationKey = "networking.gke.io/nic-info"
 	// InterfaceStatusAnnotationKey is the key of the annotation which shows information of each interface of a pod.
 	InterfaceStatusAnnotationKey = "networking.gke.io/interface-status"
-	// NetworkGatewayIPAnnotationKey is the network annotation key used to hold egress NAT gateway IP.
-	NetworkGatewayIPAnnotationKey = "networking.gke.io/gateway-ip"
 )
 
 // InterfaceAnnotation is the value of the interface annotation.


### PR DESCRIPTION
This reverts commit 79f5d136c746eeff2f92df8f0d315c6ecb70c35e.

This annotation is not part of network api