### PR TITLE
Grant dependabot write permissions on PR events.

### DIFF
--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -19,6 +19,8 @@ jobs:
   regenerate-crds:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'GoogleCloudPlatform/gke-networking-api'
+    permissions:
+      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
It seems the workflow needs explicit permissions to push commits:

> remote: Permission to GoogleCloudPlatform/gke-networking-api.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/GoogleCloudPlatform/gke-networking-api/': The requested URL returned error: 403
> Error: Process completed with exit code 128.

We're specifying `contents: write` for dependabot's job:

* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token.