### PR TITLE
Add dhanvigoog to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ reviewers:
 - aojea
 - mskrocki
 - bowei
+- dhanvigoog
 - liuyuan10
 - shouri007
 - thebeezee
@@ -10,6 +11,7 @@ approvers:
 - aojea
 - mskrocki
 - bowei
+- dhanvigoog
 - liuyuan10
 - shouri007
 - thebeezee


### PR DESCRIPTION
Require owner/approver access in order to create / approve commits related to the Multi-Networking for IPv6 effort, such as updating the Network CRD.