### PR TITLE
Add gsmanju1257 to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@ reviewers:
 - mskrocki
 - bowei
 - dhanvigoog
+- gsmanju1257
 - liuyuan10
 - shouri007
 - thebeezee
@@ -12,6 +13,7 @@ approvers:
 - mskrocki
 - bowei
 - dhanvigoog
+- gsmanju1257
 - liuyuan10
 - shouri007
 - thebeezee


### PR DESCRIPTION
Adding `gsmanju1257` as a reviewer and approver in the `OWNERS` file. 
This access is required in order to review, approve, and merge commits related to the Multi-Networking for IPv6 effort.