### PR TITLE
Add StackType and Gateway6 to Network API types

### DIFF
--- a/apis/network/v1/network_types.go
+++ b/apis/network/v1/network_types.go
@@ -75,6 +75,19 @@ const (
 	ExternalMode IPAMModeType = "External"
 )
 
+// StackType defines the IP stack mode for the network.
+// +kubebuilder:validation:Enum=ipv4;ipv6;ipv4-ipv6
+type StackType string
+
+const (
+	// IPv4StackType enables IPv4 only on the network.
+	IPv4StackType StackType = "ipv4"
+	// IPv6StackType enables IPv6 only on the network.
+	IPv6StackType StackType = "ipv6"
+	// DualStackType enables both IPv4 and IPv6 on the network.
+	DualStackType StackType = "ipv4-ipv6"
+)
+
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
@@ -129,6 +142,16 @@ type NetworkSpec struct {
 	// Required if ExternalDHCP4 is false or not set on L2 type network.
 	// +optional
 	Gateway4 *string `json:"gateway4,omitempty"`
+
+	// Gateway6 defines the gateway IPv6 address for the network.
+	// +optional
+	Gateway6 *string `json:"gateway6,omitempty"`
+
+	// StackType specifies the IP stack mode of the network.
+	// Valid options include: ipv4, ipv6, ipv4-ipv6
+	// +optional
+	// +kubebuilder:default="ipv4"
+	StackType StackType `json:"stackType,omitempty"`
 
 	// Specifies the DNS configuration of the network.
 	// Required if ExternalDHCP4 is false or not set on L2 type network.

--- a/apis/network/v1/zz_generated.deepcopy.go
+++ b/apis/network/v1/zz_generated.deepcopy.go
@@ -438,6 +438,11 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Gateway6 != nil {
+		in, out := &in.Gateway6, &out.Gateway6
+		*out = new(string)
+		**out = **in
+	}
 	if in.DNSConfig != nil {
 		in, out := &in.DNSConfig, &out.DNSConfig
 		*out = new(DNSConfig)

--- a/config/crds/networking.gke.io_networks.yaml
+++ b/config/crds/networking.gke.io_networks.yaml
@@ -102,6 +102,9 @@ spec:
                   Gateway4 defines the gateway IPv4 address for the network.
                   Required if ExternalDHCP4 is false or not set on L2 type network.
                 type: string
+              gateway6:
+                description: Gateway6 defines the gateway IPv6 address for the network.
+                type: string
               l2NetworkConfig:
                 description: L2NetworkConfig includes all the network config related
                   to L2 type network
@@ -190,6 +193,16 @@ spec:
                   - to
                   type: object
                 type: array
+              stackType:
+                default: ipv4
+                description: |-
+                  StackType specifies the IP stack mode of the network.
+                  Valid options include: ipv4, ipv6, ipv4-ipv6
+                enum:
+                - ipv4
+                - ipv6
+                - ipv4-ipv6
+                type: string
               type:
                 description: |-
                   Type defines type of network.


### PR DESCRIPTION
Adds StackType enum (ipv4, ipv6, ipv4-ipv6), Gateway6 field, and stackType field to Network spec. Updated deepcopy functions and OpenAPI CRD manifests. Needed for Task 1 GKE Multi-Network IPv6 project.

TESTED=Ran go test ./... in gke-networking-api.
TAG=agy