### PR TITLE
Extend NorthInterface struct with IPv6Address field

### DIFF
--- a/apis/network/v1/annotations.go
+++ b/apis/network/v1/annotations.go
@@ -179,8 +179,10 @@ type NodeNetwork struct {
 type NorthInterface struct {
 	// Name of the network an interface on node is connected to.
 	Network string `json:"network"`
-	// IP address of the interface.
-	IpAddress string `json:"ipAddress"`
+	// IpAddress is the IPv4 underlay/parent address of the interface on the node.
+	IpAddress string `json:"ipAddress,omitempty"`
+	// IPv6Address is the underlay/parent IPv6 address of the interface on the node.
+	IPv6Address string `json:"ipv6Address,omitempty"`
 }
 
 // InterfaceStatus holds information of a NIC of a pod.

--- a/apis/network/v1/annotations_test.go
+++ b/apis/network/v1/annotations_test.go
@@ -212,6 +212,14 @@ func TestParseNorthInterfacesAnnotation(t *testing.T) {
 			},
 			expected: `[{"network":"network-a","ipAddress":"10.0.0.1"},{"network":"network-b","ipAddress":"20.0.0.1"}]`,
 		},
+		{
+			name: "list with dual-stack and ipv6 items",
+			input: NorthInterfacesAnnotation{
+				{Network: "network-a", IpAddress: "10.0.0.1", IPv6Address: "2001:db8::1"},
+				{Network: "network-b", IPv6Address: "2001:db8::2"},
+			},
+			expected: `[{"network":"network-a","ipAddress":"10.0.0.1","ipv6Address":"2001:db8::1"},{"network":"network-b","ipv6Address":"2001:db8::2"}]`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Extends the NorthInterface annotation struct in networking.gke.io with an explicit IPv6Address field and marks IpAddress as omitempty to support dual-stack and IPv6-only secondary network interfaces in GKE Multi-Networking.

TESTED=Ran 'go test -v ./apis/network/v1/...' and 'go test ./...' in gke-networking-api repo. 
TAG=agy