### PR TITLE
Extend NICInfoRef struct with BirthIPv6 field

### DIFF
--- a/apis/network/v1/annotations.go
+++ b/apis/network/v1/annotations.go
@@ -97,6 +97,8 @@ type NICInfoAnnotation []NICInfoRef
 type NICInfoRef struct {
 	// First IP address of the interface.
 	BirthIP string `json:"birthIP,omitempty"`
+	// BirthIPv6 is the primary IPv6 address assigned to this interface at node boot time.
+	BirthIPv6 string `json:"birthIPv6,omitempty"`
 	// PCI address of this device on the node.
 	PCIAddress string `json:"pciAddress,omitempty"`
 	// Name is the birth name of this interface at node boot time.

--- a/apis/network/v1/annotations_test.go
+++ b/apis/network/v1/annotations_test.go
@@ -260,6 +260,14 @@ func TestParseNICInfoAnnotation(t *testing.T) {
 			},
 			expected: `[{"birthIP":"10.0.0.1","pciAddress":"0000:00:05.0","birthName":"eth1"},{"birthIP":"20.0.0.1","pciAddress":"0000:00:06.0","birthName":"eth2"}]`,
 		},
+		{
+			name: "list with dual-stack and ipv6 items",
+			input: NICInfoAnnotation{
+				{BirthIP: "10.0.0.1", BirthIPv6: "2001:db8::1", PCIAddress: "0000:00:05.0", BirthName: "eth1"},
+				{BirthIPv6: "2001:db8::2", PCIAddress: "0000:00:06.0", BirthName: "eth2"},
+			},
+			expected: `[{"birthIP":"10.0.0.1","birthIPv6":"2001:db8::1","pciAddress":"0000:00:05.0","birthName":"eth1"},{"birthIPv6":"2001:db8::2","pciAddress":"0000:00:06.0","birthName":"eth2"}]`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Extends the NICInfoRef annotation struct in networking.gke.io with an explicit BirthIPv6 field to record primary IPv6 addresses assigned by GCE metadata in GKE Multi-Networking.

TESTED=Ran 'go test -v ./apis/network/v1/...' in gke-networking-api repo. TAG=agy