### PR TITLE
Extend PodIP struct with IPv6 field

### DIFF
--- a/apis/network/v1/annotations.go
+++ b/apis/network/v1/annotations.go
@@ -159,8 +159,11 @@ type PodIP struct {
 	// NetworkName refers to the network object associated with this IP.
 	NetworkName string `json:"networkName"`
 
-	// IP is an IP address (IPv4 or IPv6) assigned to the pod.
-	IP string `json:"ip"`
+	// IP is an IPv4 address assigned to the pod.
+	IP string `json:"ip,omitempty"`
+
+	// IPv6 is an IPv6 address assigned to the pod.
+	IPv6 string `json:"ipv6,omitempty"`
 }
 
 // NodeNetwork specifies network data on a node.

--- a/apis/network/v1/annotations_test.go
+++ b/apis/network/v1/annotations_test.go
@@ -60,6 +60,14 @@ func TestPodIPsAnnotation(t *testing.T) {
 			},
 			expected: `[{"networkName":"network-a","ip":"198.51.100.0"},{"networkName":"network-b","ip":"2001:db8::"}]`,
 		},
+		{
+			name: "dual-stack and ipv6 pod IPs",
+			input: PodIPsAnnotation{
+				{NetworkName: "network-a", IP: "198.51.100.10", IPv6: "2001:db8::10"},
+				{NetworkName: "network-b", IPv6: "2001:db8::20"},
+			},
+			expected: `[{"networkName":"network-a","ip":"198.51.100.10","ipv6":"2001:db8::10"},{"networkName":"network-b","ipv6":"2001:db8::20"}]`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Extends the PodIP annotation struct in networking.gke.io with an explicit IPv6 field and marks IP as omitempty to track /128 container lease assignments in dual-stack and IPv6-only GKE Multi-Networking.

TESTED=Ran 'go test -v ./apis/network/v1/...' in gke-networking-api repo. TAG=agy