### PR TITLE
Add Gateway6 to InterfaceStatus and NetworkInterfaceStatus

### DIFF
--- a/apis/network/v1/annotations.go
+++ b/apis/network/v1/annotations.go
@@ -204,6 +204,9 @@ type InterfaceStatus struct {
 	// Gateway4 defines the gateway IPv4 address for the network this interface connects to.
 	Gateway4 *string `json:"gateway4,omitempty"`
 
+	// Gateway6 defines the gateway IPv6 address for the network this interface connects to.
+	Gateway6 *string `json:"gateway6,omitempty"`
+
 	// DNSConfig specifies the DNS configuration of the network this interface connects to.
 	DNSConfig *DNSConfig `json:"dnsConfig,omitempty"`
 

--- a/apis/network/v1/annotations_test.go
+++ b/apis/network/v1/annotations_test.go
@@ -340,6 +340,28 @@ func TestInterfaceStatusAnnotation(t *testing.T) {
 			expected: `[{"networkName":"network","ipAddresses":["1.2.3.4","ff::01"],"macAddress":"aa:bb:cc:dd:ee","routes":[{"to":"10.0.0.0/24"}],"gateway4":"10.0.0.1","dnsConfig":{"nameservers":["8.8.8.8"],"searches":["a.domain"]},"dhcpServerIP":"10.0.0.2"}]`,
 		},
 		{
+			name: "dual-stack status with gateway6",
+			input: InterfaceStatusAnnotation{
+				InterfaceStatus{
+					NetworkName: "network",
+					IPAddresses: []string{"1.2.3.4", "2001:db8::10"},
+					MACAddress:  "aa:bb:cc:dd:ee",
+					Routes: []Route{
+						{To: "10.0.0.0/24"},
+						{To: "2001:db8::/64"},
+					},
+					Gateway4: ptr.To("10.0.0.1"),
+					Gateway6: ptr.To("2001:db8::1"),
+					DNSConfig: &DNSConfig{
+						Nameservers: []string{"8.8.8.8", "2001:4860:4860::8888"},
+						Searches:    []string{"a.domain"},
+					},
+					DHCPServerIP: ptr.To("10.0.0.2"),
+				},
+			},
+			expected: `[{"networkName":"network","ipAddresses":["1.2.3.4","2001:db8::10"],"macAddress":"aa:bb:cc:dd:ee","routes":[{"to":"10.0.0.0/24"},{"to":"2001:db8::/64"}],"gateway4":"10.0.0.1","gateway6":"2001:db8::1","dnsConfig":{"nameservers":["8.8.8.8","2001:4860:4860::8888"],"searches":["a.domain"]},"dhcpServerIP":"10.0.0.2"}]`,
+		},
+		{
 			name: "multiple interfaces",
 			input: InterfaceStatusAnnotation{
 				InterfaceStatus{

--- a/apis/network/v1/networkinterface_types.go
+++ b/apis/network/v1/networkinterface_types.go
@@ -72,6 +72,10 @@ type NetworkInterfaceStatus struct {
 	// Gateway4 defines the gateway IPv4 address for the network this interface connects to.
 	Gateway4 *string `json:"gateway4,omitempty"`
 
+	// Gateway6 defines the gateway IPv6 address for the network this interface connects to.
+	// +optional
+	Gateway6 *string `json:"gateway6,omitempty"`
+
 	// Specifies the DNS configuration of the network this interface connects to.
 	// +optional
 	DNSConfig *DNSConfig `json:"dnsConfig,omitempty"`

--- a/apis/network/v1/zz_generated.deepcopy.go
+++ b/apis/network/v1/zz_generated.deepcopy.go
@@ -315,6 +315,11 @@ func (in *NetworkInterfaceStatus) DeepCopyInto(out *NetworkInterfaceStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Gateway6 != nil {
+		in, out := &in.Gateway6, &out.Gateway6
+		*out = new(string)
+		**out = **in
+	}
 	if in.DNSConfig != nil {
 		in, out := &in.DNSConfig, &out.DNSConfig
 		*out = new(DNSConfig)

--- a/config/crds/networking.gke.io_networkinterfaces.yaml
+++ b/config/crds/networking.gke.io_networkinterfaces.yaml
@@ -125,6 +125,10 @@ spec:
                 description: Gateway4 defines the gateway IPv4 address for the network
                   this interface connects to.
                 type: string
+              gateway6:
+                description: Gateway6 defines the gateway IPv6 address for the network
+                  this interface connects to.
+                type: string
               ipAddresses:
                 description: IpAddresses are the IP addresses assigned to the NetworkInterface.
                 items:


### PR DESCRIPTION
Adds Gateway6 field to InterfaceStatus annotation struct and NetworkInterfaceStatus CRD type to support IPv6 gateways on secondary network interfaces in GKE Multi-Networking. Updated deepcopy functions and OpenAPI CRD manifests.

TESTED=Ran 'go test -v ./apis/network/v1/...', 'go vet ./...', and './hack/verify-codegen.sh' in gke-networking-api repo. TAG=agy